### PR TITLE
do not highlight impassible tiles in routeplanner

### DIFF
--- a/chrome/nav.js
+++ b/chrome/nav.js
@@ -679,7 +679,9 @@ function showpath( event ){
 			n += -Math.sign(selectedy)*navSizeHor;
 
 		var cur_tile = navidx[ 'tdNavField' + n ];
-		highlightTileInPath( cur_tile );
+		if (!cur_tile.classList.contains('navImpassable')) {
+			highlightTileInPath( cur_tile );
+		}
 	}
 }
 


### PR DESCRIPTION
no longer highlight impassible tiles.

not as good as fully implementing auto-pilot style navigation pathing though.

![image](https://user-images.githubusercontent.com/5103517/53905337-4efa5e80-4016-11e9-9529-5b9fec52056b.png)
![image](https://user-images.githubusercontent.com/5103517/53905417-879a3800-4016-11e9-81d1-88440a25fe0a.png)

partially addresses #53 